### PR TITLE
Make GitHub detect *.hsf as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hsf linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your .hsf files as Forth.

Thank you,  
Lars Brinkhoff